### PR TITLE
add cleanup workflow

### DIFF
--- a/.github/scripts/cleanup-deployments.sh
+++ b/.github/scripts/cleanup-deployments.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+
+# That is list the files of type directory whose name does not contain
+# a non-digit. So we only process automated deployments.
+# 
+# Without LC_ALL=C, some find implementations, including GNU find could
+# also list files whose name contains sequences of bytes that don't form
+# valid characters in the current locale (like a répertoire encoded in
+# iso8859-1 (mkdir $'r\xe9pertoire') in a locale that uses UTF-8 as charset).
+DEPLOYMENTS=$(LC_ALL=C find . -maxdepth 1 ! -name '*[!0-9]*' -type d -printf '%p\n')
+
+
+for instance in $DEPLOYMENTS
+do
+    find "$instance" -maxdepth 1 -mindepth 1 -type d -printf '%p\n' | sort -g | head -n -3 | xargs rm -rf
+done

--- a/.github/workflows/cleanup-deployments.yml
+++ b/.github/workflows/cleanup-deployments.yml
@@ -1,0 +1,28 @@
+name: Cleanup Deployments
+
+# cleans up old deployments and only leaves the newest three from each PR.
+# Does not (yet) remove deployments after an PR was merged or closed.
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+
+jobs:
+  delete-old-deployments:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v3
+      with:
+        ref: gh-pages
+
+    - name: Run cleanup script
+      run: ./.github/scripts/cleanup-deployments.sh
+      shell: bash
+
+    - name: Commit changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        branch: gh-pages
+        commit_message: Cleanup and delete old deployments


### PR DESCRIPTION
Removes old deployments and only leaves the newest three from each PR.

Does not (yet) remove deployments after a PR was merged or closed.